### PR TITLE
Fix locking when modifying camera parameter maps

### DIFF
--- a/src/camera/ofxASICameraGui.cpp
+++ b/src/camera/ofxASICameraGui.cpp
@@ -86,7 +86,7 @@ void ofxASICameraGui::connect(int _cameraIndex)
     auto controls = camera.getAllControls();
     log(OF_LOG_NOTICE, "[CONNECT] number of controls: " + ofToString(controls.size()));
     {
-        std::shared_lock controlLock(updateControlsMutex);
+        std::unique_lock controlLock(updateControlsMutex);
         intParams.clear();
         boolParams.clear();
         autoParams.clear();
@@ -127,7 +127,7 @@ void ofxASICameraGui::connect(int _cameraIndex)
         else
         {
             {
-                std::shared_lock controlLock(updateControlsMutex);
+                std::unique_lock controlLock(updateControlsMutex);
                 auto &param = intParams[cap.ControlType];
                 if (cap.ControlType == ASI_EXPOSURE)
                 {
@@ -144,7 +144,7 @@ void ofxASICameraGui::connect(int _cameraIndex)
         if (cap.IsAutoSupported)
         {
             {
-                std::shared_lock controlLock(updateControlsMutex);
+                std::unique_lock controlLock(updateControlsMutex);
                 auto name = std::string("Auto_") + cap.Name;
                 auto &toggle = autoParams[cap.ControlType];
                 toggle.set(name, bAuto);
@@ -379,7 +379,7 @@ void ofxASICameraGui::updateControlLoop()
     while (bThreadRunning)
     {
         {
-            std::shared_lock controlLock(updateControlsMutex);
+            std::unique_lock controlLock(updateControlsMutex);
             for (auto &[type, param] : intParams)
             {
                 bool autoMode;


### PR DESCRIPTION
## Summary
- protect `intParams`, `boolParams` and `autoParams` modifications with `std::unique_lock`

## Testing
- `make` *(fails: no openFrameworks build files)*

------
https://chatgpt.com/codex/tasks/task_e_6842bc2d7a348323b0251d0a4fc074d7