### PR TITLE
Clear control parameter listeners on disconnect

### DIFF
--- a/src/camera/ofxASICameraGui.cpp
+++ b/src/camera/ofxASICameraGui.cpp
@@ -190,6 +190,27 @@ void ofxASICameraGui::disconnect()
     imageTypeToggleGroup.getParameter().removeListener(this, &ofxASICameraGui::onImageTypeChanged);
     modeToggleGroup.getParameter().removeListener(this, &ofxASICameraGui::onModeChanged);
     softTriggerButton.removeListener(this, &ofxASICameraGui::onSoftTriggerPressed);
+
+    {
+        std::shared_lock controlLock(updateControlsMutex);
+        for (auto &[type, param] : intParams)
+        {
+            param.removeListener(this, &ofxASICameraGui::onParamIntChanged);
+        }
+        intParams.clear();
+
+        for (auto &[type, param] : boolParams)
+        {
+            param.removeListener(this, &ofxASICameraGui::onParamBoolChanged);
+        }
+        boolParams.clear();
+
+        for (auto &[type, toggle] : autoParams)
+        {
+            toggle.removeListener(this, &ofxASICameraGui::onAutoParamChanged);
+        }
+        autoParams.clear();
+    }
     log(OF_LOG_NOTICE, "[EXIT] ofxASICameraGui::disconnect: Fin");
 }
 


### PR DESCRIPTION
## Summary
- prevent parameter callbacks from firing after the GUI is destroyed
- remove all listeners from int/bool/auto parameter maps
- clear the parameter containers

## Testing
- `make Debug` *(fails: No rule to make target `../../../libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk`)*

------
https://chatgpt.com/codex/tasks/task_e_6842bc346cb48323ba086727151b4432