### PR TITLE
Fix thread cleanup order in OSC control

### DIFF
--- a/src/osc/ofxOSCControl.cpp
+++ b/src/osc/ofxOSCControl.cpp
@@ -156,11 +156,11 @@ void ofxOSCControl::exit()
 {
     ofLogNotice() << "[OSC] >>> exit()";
     log(OF_LOG_NOTICE, "[EXIT] ofxOSCControl::exit: Début");
-    cameraManagerGui = nullptr;
-    logPanel = nullptr;
     stopThread();
     log(OF_LOG_NOTICE, "[EXIT] ofxOSCControl::exit: Thread arrêté");
     waitForThread(true, 500);
+    cameraManagerGui = nullptr;
+    logPanel = nullptr;
     try
     {
         saveSettings();


### PR DESCRIPTION
## Summary
- ensure `ofxOSCControl::exit()` stops thread and waits before nulling GUI pointers

## Testing
- `make -n` *(fails: No rule to make target)*
- `./build.sh Release` *(fails: openFrameworks makefile missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842bc38b72483239a2c7c29ddfbbf95