### PR TITLE
Fix OSC message handling to keep thread running

### DIFF
--- a/src/osc/ofxOSCControl.cpp
+++ b/src/osc/ofxOSCControl.cpp
@@ -123,7 +123,7 @@ void ofxOSCControl::threadedFunction()
                         }
                     }
                     if (m.getNumArgs() == 0)
-                        return;
+                        continue;
 
                     std::string controlTypeString = addressParts[2];
                     auto controlType = getControlTypeFromString(controlTypeString);


### PR DESCRIPTION
## Summary
- keep OSC thread alive when a message with no args arrives

## Testing
- `make Release` *(fails: No rule to make target '../../../libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk')*

------
https://chatgpt.com/codex/tasks/task_e_6842bc3cbad48323b8d680ae8f955a58