### PR TITLE
Add destructor for cleanup in ofxASICameraGui

### DIFF
--- a/src/camera/ofxASICameraGui.cpp
+++ b/src/camera/ofxASICameraGui.cpp
@@ -2,6 +2,16 @@
 #include "ofxASICameraGui.h"
 #include "cameraTools.h"
 
+ofxASICameraGui::~ofxASICameraGui()
+{
+    log(OF_LOG_NOTICE, "[GUI] >>> Destructor ~ofxASICameraGui");
+    if (isConnected || (updateControlsThread && updateControlsThread->joinable()))
+    {
+        disconnect();
+    }
+    log(OF_LOG_NOTICE, "[GUI] <<< Destructor ~ofxASICameraGui");
+}
+
 void ofxASICameraGui::setup(LogPanel *logPanel)
 {
     this->logPanel = logPanel;

--- a/src/camera/ofxASICameraGui.h
+++ b/src/camera/ofxASICameraGui.h
@@ -9,6 +9,7 @@
 class ofxASICameraGui
 {
 public:
+    ~ofxASICameraGui();
     void setup(LogPanel *logPanel);
     void connect(int _cameraIndex);
     void disconnect();


### PR DESCRIPTION
## Summary
- ensure proper cleanup by adding destructor to `ofxASICameraGui`

## Testing
- `make -n` *(fails: No rule to make target '../../../libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk')*

------
https://chatgpt.com/codex/tasks/task_e_6842bc3fae2c8323aae9c7ade0c32707