### PR TITLE
Fix Info.plist generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ https://www.zwoastro.com/product/asi2600/
 - openFrameworks 0.12.0: https://openframeworks.cc/download/
 - ofxSyphon addon: https://github.com/astellato/ofxSyphon (must be installed in the openFrameworks addons folder)
 
+**Important**: The application depends on the proprietary `ASICamera2` library
+which only provides x86_64 binaries. If you are on Apple Silicon, compile and
+run the project using Rosetta so that the executable remains in x86_64.
+
 ## Installation and Compilation
 
 Important: The `ZWOCameraBridge` project folder must be placed in the following directory of your openFrameworks installation:

--- a/build.sh
+++ b/build.sh
@@ -75,7 +75,16 @@ cp "$SCRIPT_DIR/resources/AppIcon.icns" "$APP_BUNDLE/Contents/Resources/"
 PLIST_FILE="${APP_BUNDLE}/Contents/Info.plist"
 
 # Injecte l'icône dans le plist si besoin
-echo "[Post-Build] Insertion CFBundleIconFile dans Info.plist"
+echo "[Post-Build] Updating Info.plist"
+# Ensure the executable and bundle identifiers are correctly set so the
+# generated .app is recognised by Finder. This prevents the
+# "application is damaged" error when launching.
+/usr/libexec/PlistBuddy -c "Set :CFBundleExecutable ${APP_NAME}" "$PLIST_FILE" 2>/dev/null || \
+/usr/libexec/PlistBuddy -c "Add :CFBundleExecutable string ${APP_NAME}" "$PLIST_FILE"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName ${APP_NAME}" "$PLIST_FILE" 2>/dev/null || \
+/usr/libexec/PlistBuddy -c "Add :CFBundleName string ${APP_NAME}" "$PLIST_FILE"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier net.zwocamerabridge.${APP_NAME}" "$PLIST_FILE" 2>/dev/null || \
+/usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string net.zwocamerabridge.${APP_NAME}" "$PLIST_FILE"
 /usr/libexec/PlistBuddy -c "Set :CFBundleIconFile AppIcon" "$PLIST_FILE" 2>/dev/null || \
 /usr/libexec/PlistBuddy -c "Add :CFBundleIconFile string AppIcon" "$PLIST_FILE"
 


### PR DESCRIPTION
## Summary
- fix Info.plist writing so Finder can launch the app
- document that ASICamera2 only supports x86_64 and the app should be built under Rosetta

## Testing
- `./build.sh Debug` *(fails: missing openFrameworks)*

------
https://chatgpt.com/codex/tasks/task_e_6842c6313ff08323a703d896e7573e6c