### PR TITLE
Add CI release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install openFrameworks
+        run: |
+          curl -L https://github.com/openframeworks/openFrameworks/releases/download/0.12.0/of_v0.12.0_osx_release.zip -o of.zip
+          unzip -q of.zip
+          mv of_v0.12.0_osx_release ..
+      - name: Build application
+        run: ./build.sh Release
+      - name: Package DMG
+        run: |
+          cd bin
+          hdiutil create -volname ZWOCameraBridge -srcfolder ZWOCameraBridge.app -ov -format UDZO ZWOCameraBridge.dmg
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: bin/ZWOCameraBridge.dmg
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ _CodeSignature/
 
 # Fichiers de configuration utilisateur
 settings.xml
+
+# Fichiers d'images disque
+*.dmg

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,38 @@
+stages:
+  - build
+  - release
+
+variables:
+  APP_NAME: "ZWOCameraBridge"
+
+build:
+  stage: build
+  tags:
+    - macos
+  script:
+    - curl -L https://github.com/openframeworks/openFrameworks/releases/download/0.12.0/of_v0.12.0_osx_release.zip -o of.zip
+    - unzip -q of.zip
+    - mv of_v0.12.0_osx_release ..
+    - ./build.sh Release
+    - cd bin
+    - hdiutil create -volname "$APP_NAME" -srcfolder "$APP_NAME.app" -ov -format UDZO "$APP_NAME.dmg"
+  artifacts:
+    paths:
+      - bin/${APP_NAME}.dmg
+
+release:
+  stage: release
+  dependencies:
+    - build
+  script:
+    - echo "Release created"
+  release:
+    name: "$CI_COMMIT_TAG"
+    tag_name: "$CI_COMMIT_TAG"
+    description: "Release $CI_COMMIT_TAG"
+    assets:
+      links:
+        - name: "${APP_NAME}.dmg"
+          url: "${CI_PROJECT_URL}/-/jobs/$CI_JOB_ID/artifacts/file/bin/${APP_NAME}.dmg"
+  only:
+    - tags

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The binary will be generated in the `bin/` folder.
 
 Launch the application from the `bin/ZWOCameraBridge.app` folder or via the terminal after compilation.
 
+## Continuous Integration
+
+GitHub Actions and GitLab CI pipelines build the application when a tag starting with `v` is pushed. The workflows download openFrameworks, run `build.sh` and create a DMG that is attached to the release.
+
 ---
 
 © 2025 - Johan Lescure.

--- a/build.sh
+++ b/build.sh
@@ -90,3 +90,6 @@ echo "[Post-Build] Updating Info.plist"
 
 cd "$SCRIPT_DIR/bin"
 zip -r "${APP_NAME}.zip" "${APP_NAME}.app"
+
+echo "[Post-Build] Creating DMG"
+hdiutil create -volname "${APP_NAME}" -srcfolder "${APP_NAME}.app" -ov -format UDZO "${APP_NAME}.dmg"


### PR DESCRIPTION
## Summary
- package a DMG after building
- ignore DMG files in git
- document CI pipelines
- add GitHub Actions and GitLab CI for macOS releases

## Testing
- `bash -n build.sh`
- `./build.sh Release` *(fails: make: *** No rule to make target...)*

------
https://chatgpt.com/codex/tasks/task_e_6842c843ed508323999f9d8405b5d540