### PR TITLE
Fix CI build for missing ofxSyphon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
           curl -L https://github.com/openframeworks/openFrameworks/releases/download/0.12.0/of_v0.12.0_osx_release.zip -o of.zip
           unzip -q of.zip
           mv of_v0.12.0_osx_release ..
+      - name: Install addons
+        run: |
+          git clone --depth 1 https://github.com/astellato/ofxSyphon ../of_v0.12.0_osx_release/addons/ofxSyphon
       - name: Build application
         run: ./build.sh Release
       - name: Package DMG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@ build:
     - curl -L https://github.com/openframeworks/openFrameworks/releases/download/0.12.0/of_v0.12.0_osx_release.zip -o of.zip
     - unzip -q of.zip
     - mv of_v0.12.0_osx_release ..
+    - git clone --depth 1 https://github.com/astellato/ofxSyphon ../of_v0.12.0_osx_release/addons/ofxSyphon
     - ./build.sh Release
     - cd bin
     - hdiutil create -volname "$APP_NAME" -srcfolder "$APP_NAME.app" -ov -format UDZO "$APP_NAME.dmg"


### PR DESCRIPTION
## Summary
- clone ofxSyphon during CI builds so the project compiles
- apply same fix for GitLab CI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842d36a67ec8323873d61d25ad72b6a