### PR TITLE
Fix build on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ https://www.zwoastro.com/product/asi2600/
 - ofxSyphon addon: https://github.com/astellato/ofxSyphon (must be installed in the openFrameworks addons folder)
 
 **Important**: The application depends on the proprietary `ASICamera2` library
-which only provides x86_64 binaries. If you are on Apple Silicon, compile and
-run the project using Rosetta so that the executable remains in x86_64.
+which only provides x86_64 binaries. If you are on Apple Silicon, make sure the
+build happens under Rosetta so the executable remains in x86_64. The `build.sh`
+script detects Apple Silicon and invokes `make` using `arch -x86_64`
+automatically.
 
 ## Installation and Compilation
 

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,14 @@ APP_BUNDLE="bin/${APP_NAME}.app"
 FRAMEWORKS_PATH="${APP_BUNDLE}/Contents/Frameworks"
 
 echo "Building in $MODE mode..."
-make $MODE || exit 1
+
+# Ensure compilation happens for x86_64 when running on Apple Silicon
+if [[ "$(uname -m)" == "arm64" ]]; then
+    echo "Running make under Rosetta..."
+    arch -x86_64 make $MODE || exit 1
+else
+    make $MODE || exit 1
+fi
 
 echo "[Post-Build] Copie de ${DYLIB_NAME}"
 mkdir -p "$FRAMEWORKS_PATH"


### PR DESCRIPTION
## Summary
- ensure Apple Silicon builds run under Rosetta by calling `arch -x86_64`
- document automatic Rosetta detection in README

## Testing
- `./build.sh Release` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6842d516e4288323b27884ff7e0bd9f8