### PR TITLE
Fix CI openFrameworks directory overwrite

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ build:
   script:
     - curl -L https://github.com/openframeworks/openFrameworks/releases/download/0.12.0/of_v0.12.0_osx_release.zip -o of.zip
     - unzip -q of.zip
+    - rm -rf ../of_v0.12.0_osx_release
     - mv of_v0.12.0_osx_release ..
     - git clone --depth 1 https://github.com/astellato/ofxSyphon ../of_v0.12.0_osx_release/addons/ofxSyphon
     - ./build.sh Release


### PR DESCRIPTION
## Summary
- delete any existing `of_v0.12.0_osx_release` before moving the new one

## Testing
- `make -n` *(fails: No rule to make target '../../../libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk')*

------
https://chatgpt.com/codex/tasks/task_e_6842ca34d9c083238f0c4b0d2af98e6e