### PR TITLE
Improve Syphon framework handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ https://www.zwoastro.com/product/asi2600/
 ## Requirements
 - macOS
 - openFrameworks 0.12.0: https://openframeworks.cc/download/
-- ofxSyphon addon: https://github.com/astellato/ofxSyphon (must be installed in the openFrameworks addons folder)
+ - ofxSyphon addon: https://github.com/astellato/ofxSyphon (must be installed in the openFrameworks addons folder)
+   - the build script copies `Syphon.framework` from `OF_ROOT/addons/ofxSyphon/libs/Syphon/lib/osx`. If the framework is missing at this location the build will fail.
 
 **Important**: The application depends on the proprietary `ASICamera2` library
 which only provides x86_64 binaries. If you are on Apple Silicon, make sure the

--- a/build.sh
+++ b/build.sh
@@ -58,12 +58,22 @@ install_name_tool -change "@loader_path/libusb-1.0.0.dylib" \
   "@loader_path/../Frameworks/libusb-1.0.0.dylib" \
   "${FRAMEWORKS_PATH}/${DYLIB_NAME}"
 
-# Chemin vers Syphon.framework (fourni par ofxSyphon)
-SYPHON_SOURCE="$SCRIPT_DIR/../../../addons/ofxSyphon/libs/Syphon/lib/osx/Syphon.framework"
+# Determine the openFrameworks root just like config.make does
+OF_ROOT="$(realpath "$SCRIPT_DIR/../of_v0.12.0_osx_release")"
+if [ ! -f "$OF_ROOT/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk" ]; then
+    OF_ROOT="$(realpath "$SCRIPT_DIR/../../..")"
+fi
+
+# Path to Syphon.framework (provided by ofxSyphon)
+SYPHON_SOURCE="$OF_ROOT/addons/ofxSyphon/libs/Syphon/lib/osx/Syphon.framework"
 SYPHON_DEST="$FRAMEWORKS_PATH/Syphon.framework"
 
 # Copie si non déjà présent
 if [ ! -d "$SYPHON_DEST" ]; then
+    if [ ! -d "$SYPHON_SOURCE" ]; then
+        echo "Error: Syphon.framework not found at $SYPHON_SOURCE" >&2
+        exit 1
+    fi
     echo "[Post-Build] Copying Syphon.framework..."
     cp -R "$SYPHON_SOURCE" "$SYPHON_DEST"
 fi


### PR DESCRIPTION
## Summary
- compute `OF_ROOT` in `build.sh` so Syphon.framework can be found
- fail the build if the framework isn't available
- document the Syphon framework location in README

## Testing
- `make Release` *(fails: No rule to make target `../../../libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk`)*

------
https://chatgpt.com/codex/tasks/task_e_6842d95c3d108323962504df020bafc4