### PR TITLE
Fix Syphon.framework copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://www.zwoastro.com/product/asi2600/
 - macOS
 - openFrameworks 0.12.0: https://openframeworks.cc/download/
  - ofxSyphon addon: https://github.com/astellato/ofxSyphon (must be installed in the openFrameworks addons folder)
-   - the build script copies `Syphon.framework` from `OF_ROOT/addons/ofxSyphon/libs/Syphon/lib/osx`. If the framework is missing at this location the build will fail.
+  - the build script copies `Syphon.framework` from `OF_ROOT/addons/ofxSyphon/libs/Syphon/lib/osx` using `ditto` to preserve the framework's symlinks. If the framework is missing at this location the build will fail.
 
 **Important**: The application depends on the proprietary `ASICamera2` library
 which only provides x86_64 binaries. If you are on Apple Silicon, make sure the

--- a/build.sh
+++ b/build.sh
@@ -75,7 +75,8 @@ if [ ! -d "$SYPHON_DEST" ]; then
         exit 1
     fi
     echo "[Post-Build] Copying Syphon.framework..."
-    cp -R "$SYPHON_SOURCE" "$SYPHON_DEST"
+    # Use ditto to preserve the framework structure and symlinks
+    ditto "$SYPHON_SOURCE" "$SYPHON_DEST"
 fi
 
 install_name_tool -change \


### PR DESCRIPTION
## Summary
- use `ditto` so Syphon.framework is bundled with its symlinks
- document the symlink-preserving copy in README

## Testing
- `./build.sh Release` *(fails: No rule to make target '../../../libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk')*

------
https://chatgpt.com/codex/tasks/task_e_6842e034b3c8832387c319421b9a0bb1