### PR TITLE
Fix deadlock when disconnecting camera

### DIFF
--- a/src/camera/ofxASICameraGui.cpp
+++ b/src/camera/ofxASICameraGui.cpp
@@ -419,7 +419,7 @@ void ofxASICameraGui::updateControlLoop()
 
                 if (autoParams.count(type))
                 {
-                    autoParams[type] = autoMode;
+                    autoParams[type].setWithoutEventNotifications(autoMode);
                 }
             }
 
@@ -431,7 +431,7 @@ void ofxASICameraGui::updateControlLoop()
 
                 if (autoParams.count(type))
                 {
-                    autoParams[type] = autoMode;
+                    autoParams[type].setWithoutEventNotifications(autoMode);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- avoid triggering auto control parameter callbacks while the control lock is held

## Testing
- `make -n` *(fails: No rule to make target ...)*

------
https://chatgpt.com/codex/tasks/task_e_6842e2ee03ac832392f386f35a11454f